### PR TITLE
Making annotation and collection properties public

### DIFF
--- a/src/AbstractAnnotation.php
+++ b/src/AbstractAnnotation.php
@@ -20,12 +20,12 @@ abstract class AbstractAnnotation
     /**
      * @var array
      */
-    protected $data;
+    public $data;
 
     /**
      * @var mixed
      */
-    protected $value;
+    public $value;
 
     /**
      * Constructor

--- a/src/AnnotationCollection.php
+++ b/src/AnnotationCollection.php
@@ -29,7 +29,7 @@ class AnnotationCollection implements IteratorAggregate, Countable
      *
      * @var AbstractAnnotation[]|AbstractAnnotation[][]
      */
-    private $annotations = [];
+    public $annotations = [];
 
     /**
      * Create new collection from array


### PR DESCRIPTION
When these classes are cached, the resulting size will be smaller